### PR TITLE
Fix translations not loading due to Turbopack incompatibility

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,8 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextTranslate = require('next-translate-plugin')
 const nextConfig = nextTranslate({
-  reactStrictMode: true,
-  turbopack: {}
+  reactStrictMode: true
 })
 
 module.exports = nextConfig

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "private": true,
   "scripts": {
-    "dev": "next",
-    "build": "next build",
+    "dev": "next dev --webpack",
+    "build": "next build --webpack",
     "start": "next start"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
Fixes translations that were displaying as raw keys (e.g., `header.fullname`) instead of translated strings.

## Problem
Next.js 16 made Turbopack the default bundler, but `next-translate-plugin` uses a webpack loader that doesn't work with Turbopack. This caused all translations to fail silently.

## Solution
- Added `--webpack` flag to `dev` and `build` scripts in package.json
- Removed `turbopack: {}` from next.config.js to force webpack usage

## Testing
- ✅ Translations now display correctly in all locales (en, ja, es)
- ✅ Build completes successfully with webpack
- ✅ Dev server works properly with `--webpack` flag

## Notes
- React 19 is NOT the issue (tested and confirmed working)
- This is a compatibility limitation between next-translate and Turbopack
- Long-term: may need to migrate to a Turbopack-compatible i18n solution

Close #560